### PR TITLE
add session id for nutaku

### DIFF
--- a/HH-Harem.user.js
+++ b/HH-Harem.user.js
@@ -49,7 +49,9 @@
             if(target != girls_list)
             {
                 while(target.getAttribute('id_girl') == null) target = target.parentNode;
-                window.open('https://'+window.location.hostname+'/girl/'+target.getAttribute('id_girl')+'?resource=experience', '_blank');
+                // on nutaku the session id is required
+                const sess = window.location.hostname.includes('nutaku') ? '&sess=' + new URLSearchParams(window.location.search).get("sess") : '';
+                window.open('https://'+window.location.hostname+'/girl/'+target.getAttribute('id_girl')+'?resource=experience' + sess, '_blank');
             }
         });
 

--- a/HH-Harem.user.js
+++ b/HH-Harem.user.js
@@ -3,21 +3,21 @@
 // @version      0.16
 // @description  Compact Harem filter, "open by default" setting, open the girl upgrade page in a new tab by double-clicking
 // @author       -MM-
-// @match        https://*.hentaiheroes.com/characters.html
+// @match        https://*.hentaiheroes.com/characters.html*
 // @match        https://*.hentaiheroes.com/characters/*
 // @match        https://nutaku.haremheroes.com/characters.html*
 // @match        https://nutaku.haremheroes.com/characters/*
 // @match        https://*.comixharem.com/characters.html
 // @match        https://*.comixharem.com/characters/*
-// @match        https://*.pornstarharem.com/characters.html
+// @match        https://*.pornstarharem.com/characters.html*
 // @match        https://*.pornstarharem.com/characters/*
-// @match        https://*.gayharem.com/characters.html
+// @match        https://*.gayharem.com/characters.html*
 // @match        https://*.gayharem.com/characters/*
-// @match        https://*.gaypornstarharem.com/characters.html
+// @match        https://*.gaypornstarharem.com/characters.html*
 // @match        https://*.gaypornstarharem.com/characters/*
-// @match        https://*.transpornstarharem.com/characters.html
+// @match        https://*.transpornstarharem.com/characters.html*
 // @match        https://*.transpornstarharem.com/characters/*
-// @match        https://*.hornyheroes.com/characters.html
+// @match        https://*.hornyheroes.com/characters.html*
 // @match        https://*.hornyheroes.com/characters/*
 // @run-at       document-end
 // @namespace    https://github.com/HH-GAME-MM/HH-Harem


### PR DESCRIPTION
Double click to open the upgrade page in a new tab gets a session not found error since the id is missing in the url.

It might be useful to also mute the alert you get when going to nutaku.haremheroes.com instead of the proper nutaku.net page. I have my own script that just does this:
```
    let alert = window.alert;
    function noIDont(message) {
        if (message == "You need to be inside Nutaku's frame for this to work.") { return; }
        alert(message);
    }
    window.alert = noIDont;
 ```